### PR TITLE
feat: log commands and support mini app button fallback

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -19,29 +19,29 @@ supabase functions serve telegram-bot --no-verify-jwt
 # Ping (expects 200)
   curl -X POST "http://127.0.0.1:54321/functions/v1/telegram-bot?secret=$TELEGRAM_WEBHOOK_SECRET" \
     -H "content-type: application/json" -d '{"test":"ping"}'
-  ```
+```
 
 ### Mini App launch options
+
 - Preferred: set `MINI_APP_SHORT_NAME` (from BotFather, e.g. `dynamic_pay`)
 - Fallback: set `MINI_APP_URL` (full https URL)
 
 ### Set a persistent chat menu button (optional)
-# Requires TELEGRAM_BOT_TOKEN set in your shell
-curl -X POST "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setChatMenuButton" \
-  -H "content-type: application/json" \
-  -d '{"menu_button":{"type":"web_app","text":"Dynamic Pay","web_app":{"short_name":"dynamic_pay"}}}'
 
-## Telegram connect (Webhook quick cmds)
+# Requires TELEGRAM_BOT_TOKEN set in your shell
+
+curl -X POST
+"https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setChatMenuButton"\
+-H "content-type: application/json"\
+-d '{"menu_button":{"type":"web_app","text":"Dynamic
+Pay","web_app":{"short_name":"dynamic_pay"}}}'
+
+## Reset & set webhook WITH secret
 
 ```bash
-# Delete existing webhook
 curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/deleteWebhook"
-
-# Set webhook with secret gate (replace <PROJECT_REF>)
 curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook?url=https://<PROJECT_REF>.functions.supabase.co/telegram-bot?secret=$TELEGRAM_WEBHOOK_SECRET"
-
-# Inspect current webhook
-curl -s "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/getWebhookInfo"
+curl -s "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/getWebhookInfo" | jq
 ```
 
-Note: /start shows Mini App button (short_name preferred, URL fallback).
+Note: /start sends the Mini App button (short_name or URL).


### PR DESCRIPTION
## Summary
- return friendly message when mini app button is unset and favor short_name over URL
- log command_received and pipeline_started events in telegram webhook
- document webhook reset & set with secret

## Testing
- `deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts` *(failed: invalid peer certificate)*
- `deno test -A` *(failed: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6896e3af6af48322abaca5b5729aa0cb