### PR TITLE
Improve Telegram command parsing and fix tesseract type mapping

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -81,11 +81,22 @@ function okJSON(body: unknown = { ok: true }): Response {
 
 async function notifyUser(chatId: number, text: string): Promise<void> {
   if (!BOT_TOKEN) return;
-  await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ chat_id: chatId, text }),
-  });
+  try {
+    const res = await fetch(
+      `https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: chatId, text }),
+      },
+    );
+    if (!res.ok) {
+      const errText = await res.text();
+      console.error("notifyUser error", errText);
+    }
+  } catch (err) {
+    console.error("notifyUser error", err);
+  }
 }
 
 function buildWebAppButton(label = "Open Mini App") {
@@ -103,17 +114,21 @@ async function sendMiniAppLink(chatId: number): Promise<void> {
   const button = buildWebAppButton("Open Mini App");
   const reply_markup = button ? { inline_keyboard: [[button]] } : undefined;
 
-  await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      chat_id: chatId,
-      text: button
-        ? "Open the Dynamic Capital mini app"
-        : "Mini app not configured yet.",
-      reply_markup,
-    }),
-  });
+  try {
+    await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text: button
+          ? "Open the Dynamic Capital mini app"
+          : "Mini app not configured yet.",
+        reply_markup,
+      }),
+    });
+  } catch (err) {
+    console.error("sendMiniAppLink error", err);
+  }
 }
 
 async function extractTelegramUpdate(
@@ -197,28 +212,46 @@ async function handleCommand(update: TelegramUpdate): Promise<void> {
   const text = msg.text?.trim();
   if (!text) return;
   const chatId = msg.chat.id;
+
+  // Extract the command without bot mentions and gather arguments
+  const [firstToken, ...args] = text.split(/\s+/);
+  const command = firstToken.split("@")[0];
+
   try {
-    if (text.startsWith("/start")) {
-      await sendMiniAppLink(chatId);
-    } else if (text === "/app") {
-      await sendMiniAppLink(chatId);
-    } else if (text === "/ping") {
-      await notifyUser(chatId, JSON.stringify(handlePing()));
-    } else if (text === "/version") {
-      await notifyUser(chatId, JSON.stringify(handleVersion()));
-    } else if (text === "/env") {
-      await notifyUser(chatId, JSON.stringify(handleEnvStatus()));
-    } else if (text === "/reviewlist") {
-      const list = await handleReviewList();
-      await notifyUser(chatId, JSON.stringify(list));
-    } else if (text.startsWith("/replay")) {
-      const id = text.split(/\s+/)[1];
-      if (id) {
-        await notifyUser(chatId, JSON.stringify(handleReplay(id)));
+    switch (command) {
+      case "/start":
+      case "/app":
+        await sendMiniAppLink(chatId);
+        break;
+      case "/ping":
+        await notifyUser(chatId, JSON.stringify(handlePing()));
+        break;
+      case "/version":
+        await notifyUser(chatId, JSON.stringify(handleVersion()));
+        break;
+      case "/env":
+        await notifyUser(chatId, JSON.stringify(handleEnvStatus()));
+        break;
+      case "/reviewlist": {
+        const list = await handleReviewList();
+        await notifyUser(chatId, JSON.stringify(list));
+        break;
       }
-    } else if (text === "/webhookinfo") {
-      const info = await handleWebhookInfo();
-      await notifyUser(chatId, JSON.stringify(info));
+      case "/replay": {
+        const id = args[0];
+        if (id) {
+          await notifyUser(chatId, JSON.stringify(handleReplay(id)));
+        }
+        break;
+      }
+      case "/webhookinfo": {
+        const info = await handleWebhookInfo();
+        await notifyUser(chatId, JSON.stringify(info));
+        break;
+      }
+      default:
+        await notifyUser(chatId, "Unsupported command");
+        break;
     }
   } catch (err) {
     console.error("handleCommand error", err);
@@ -239,12 +272,12 @@ export async function serveWebhook(req: Request): Promise<Response> {
     const { ok, missing } = requireEnv(REQUIRED_ENV_KEYS);
     if (!ok) {
       console.error("Missing env vars", missing);
-      return okJSON();
+      return new Response("Missing env vars", { status: 500 });
     }
 
     const url = new URL(req.url);
     if (url.searchParams.get("secret") !== WEBHOOK_SECRET) {
-      return okJSON();
+      return new Response("Unauthorized", { status: 401 });
     }
 
     const body = await extractTelegramUpdate(req);

--- a/supabase/functions/telegram-bot/vendor/esm.sh/tesseract.js@5.1.1.js
+++ b/supabase/functions/telegram-bot/vendor/esm.sh/tesseract.js@5.1.1.js
@@ -1,3 +1,3 @@
-// @deno-types="../../../../../../types/tesseract.d.ts"
+// @deno-types="../../../../../types/tesseract.d.ts"
 export * from "./tesseract.js@5.1.1.proxied.js";
 export { default } from "./tesseract.js@5.1.1.proxied.js";


### PR DESCRIPTION
## Summary
- Handle Telegram commands with bot mentions and arguments
- Correct tesseract type reference for Deno type checking
- Add error handling around Telegram fetches and return explicit status codes for missing env or secret
- Log Telegram API failures and reply to unsupported commands

## Testing
- `npm test` *(fails: invalid peer certificate for registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68972ef4aea88322b76591d49a3ee0f2