### PR TITLE
Improve Telegram command parsing and fix tesseract type mapping

### DIFF
--- a/supabase/functions/telegram-bot/vendor/esm.sh/tesseract.js@5.1.1.js
+++ b/supabase/functions/telegram-bot/vendor/esm.sh/tesseract.js@5.1.1.js
@@ -1,3 +1,3 @@
-// @deno-types="../../../../../../types/tesseract.d.ts"
+// @deno-types="../../../../../types/tesseract.d.ts"
 export * from "./tesseract.js@5.1.1.proxied.js";
 export { default } from "./tesseract.js@5.1.1.proxied.js";


### PR DESCRIPTION
## Summary
- Handle Telegram commands with bot mentions and arguments
- Correct tesseract type reference for Deno type checking
- Add error handling around Telegram fetches and return explicit status codes for missing env or secret
- Log Telegram API failures and reply to unsupported commands
- Surface missing TELEGRAM_BOT_TOKEN via explicit logging so misconfiguration doesn't fail silently

## Testing
- `npm test` *(fails: invalid peer certificate for registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68972ef4aea88322b76591d49a3ee0f2