### PR TITLE
feat: add bot health checks and ping endpoint

### DIFF
--- a/.github/workflows/bot_health.yml
+++ b/.github/workflows/bot_health.yml
@@ -1,0 +1,18 @@
+name: Bot Health Checks
+on:
+  workflow_dispatch:
+  pull_request:
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tools
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Install Supabase CLI
+        run: bash scripts/env/install_supabase_cli.sh
+      - name: Run health checks
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: bash scripts/bot/health_check.sh

--- a/scripts/bot/health_check.sh
+++ b/scripts/bot/health_check.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/env/require_env.sh
+
+ensure_out(){ mkdir -p .out; }
+ensure_out
+
+# Expected webhook URL from SUPABASE_URL
+BASE="${SUPABASE_URL%/}"
+EXPECTED="$BASE/functions/v1/telegram-webhook"
+
+# A1) Static code checks: look for webhook handler and /start handling
+WEBHOOK_FILE=$(git ls-files | grep -E '^supabase/functions/telegram-webhook/.+\.(ts|tsx)$' || true)
+STATIC=".out/bot_static.txt"; : > "$STATIC"
+if [ -n "$WEBHOOK_FILE" ]; then
+  echo "webhook_file=$WEBHOOK_FILE" >> "$STATIC"
+  grep -Eq "serve\\(" "$WEBHOOK_FILE" && echo "has_serve=PASS" >> "$STATIC" || echo "has_serve=FAIL" >> "$STATIC"
+  grep -Eq "req\\.method\\s*===?\\s*\"POST\"|req\\.method\\s*!==\\s*\"POST\"" "$WEBHOOK_FILE" && echo "handles_post=PASS" >> "$STATIC" || echo "handles_post=FAIL" >> "$STATIC"
+  grep -Eq "await\\s+req\\.json\\(|update\\.message|edited_message|callback_query" "$WEBHOOK_FILE" && echo "parses_update=PASS" >> "$STATIC" || echo "parses_update=FAIL" >> "$STATIC"
+  grep -Eq "\\/start" "$WEBHOOK_FILE" && echo "handles_start=PASS" >> "$STATIC" || echo "handles_start=FAIL" >> "$STATIC"
+  grep -Eq "x-telegram-bot-api-secret-token" "$WEBHOOK_FILE" && echo "secret_header=PASS" >> "$STATIC" || echo "secret_header=NA" >> "$STATIC"
+else
+  echo "webhook_file=UNKNOWN" >> "$STATIC"
+fi
+
+# B1) Deployed function reachability
+DEPLOY=".out/bot_deploy.txt"; : > "$DEPLOY"
+echo "expected=$EXPECTED" >> "$DEPLOY"
+status=$(curl -s -o /dev/null -w "%{http_code}" -m 8 "$EXPECTED" || echo 000)
+echo "head_status=$status" >> "$DEPLOY"
+post_status=$(curl -s -o /dev/null -w "%{http_code}" -m 8 -H "content-type: application/json" -d '{}' "$EXPECTED" || echo 000)
+echo "post_status=$post_status" >> "$DEPLOY"
+[ "$status" != "000" -o "$post_status" != "000" ] && echo "reachable=PASS" >> "$DEPLOY" || echo "reachable=FAIL" >> "$DEPLOY"
+
+# C1) Runtime wiring (use server-side diagnostics if available)
+RUN=".out/bot_runtime.txt"; : > "$RUN"
+GW="$BASE/functions/v1/telegram-getwebhook"
+SS="$BASE/functions/v1/telegram-start-sim"
+
+gw_code=$(curl -s -o .out/_gw.json -w "%{http_code}" -m 8 "$GW" || echo 000)
+if [ "$gw_code" = "200" ]; then
+  echo "getwebhook=PASS" >> "$RUN"
+  exp=$(jq -r '.expected_url // empty' .out/_gw.json 2>/dev/null || true)
+  cur=$(jq -r '.webhook_info.url // empty' .out/_gw.json 2>/dev/null || true)
+  if [ -n "$exp" ] && [ -n "$cur" ] && [ "$exp" = "$cur" ]; then
+    echo "webhook_match=PASS" >> "$RUN"
+  else
+    echo "webhook_match=FAIL" >> "$RUN"
+    echo "expected_url=${exp:-unknown}" >> "$RUN"
+    echo "current_url=${cur:-unknown}" >> "$RUN"
+  fi
+else
+  echo "getwebhook=UNKNOWN" >> "$RUN"
+  echo "webhook_match=UNKNOWN" >> "$RUN"
+fi
+
+# Attempt to call telegram-start-sim for completeness
+ss_code=$(curl -s -o /dev/null -w "%{http_code}" -m 8 "$SS" || echo 000)
+echo "start_sim_status=$ss_code" >> "$RUN"
+
+printf "Report:\n"
+printf " - Static: .out/bot_static.txt\n"
+printf " - Deploy: .out/bot_deploy.txt\n"
+printf " - Runtime: .out/bot_runtime.txt\n"
+

--- a/scripts/env/install_supabase_cli.sh
+++ b/scripts/env/install_supabase_cli.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Install Supabase CLI if missing (Linux/macOS). Skip if already present.
+if command -v supabase >/dev/null 2>&1; then
+  supabase --version
+  exit 0
+fi
+
+# Try official install script
+curl -fsSL https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz -o /tmp/supabase.tgz || true
+if [ -s /tmp/supabase.tgz ]; then
+  tar -xzf /tmp/supabase.tgz -C /usr/local/bin || sudo tar -xzf /tmp/supabase.tgz -C /usr/local/bin
+  chmod +x /usr/local/bin/supabase || true
+fi
+
+if ! command -v supabase >/dev/null 2>&1; then
+  echo "Supabase CLI not found after install attempt. Install manually: https://supabase.com/docs/reference/cli/usage"
+  exit 1
+fi
+supabase --version

--- a/scripts/env/require_env.sh
+++ b/scripts/env/require_env.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+require() { : "${!1:?Missing required env: $1}"; }
+require SUPABASE_URL
+# Service role is needed for some server-side checks, but NEVER echo it:
+if [ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+  echo "WARN: SUPABASE_SERVICE_ROLE_KEY not set; some server-side checks may be skipped."
+fi

--- a/supabase/functions/telegram-ping/index.ts
+++ b/supabase/functions/telegram-ping/index.ts
@@ -1,0 +1,29 @@
+// >>> DC BLOCK: telegram-ping (start)
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+
+const BOT = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+
+async function tg(method: string, payload: unknown) {
+  if (!BOT) throw new Error("TELEGRAM_BOT_TOKEN missing");
+  const r = await fetch(`https://api.telegram.org/bot${BOT}/${method}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(8000)
+  });
+  return r;
+}
+
+serve(async (req) => {
+  try {
+    const url = new URL(req.url);
+    const chatId = Number(url.searchParams.get("chat_id") || 0);
+    if (!chatId) return new Response(JSON.stringify({ ok:false, error:"chat_id required" }), { status:400, headers:{ "content-type":"application/json" } });
+    const res = await tg("sendMessage", { chat_id: chatId, text: "pong ✅ (telegram-ping)" });
+    const body = await res.text().catch(()=> "");
+    return new Response(JSON.stringify({ ok: res.ok, status: res.status, preview: body.slice(0,200) }), { headers:{ "content-type":"application/json","cache-control":"no-store" }});
+  } catch (e) {
+    return new Response(JSON.stringify({ ok:false, error:String(e) }), { status:500, headers:{ "content-type":"application/json" }});
+  }
+});
+// <<< DC BLOCK: telegram-ping (end)


### PR DESCRIPTION
## Summary
- add scripts to install Supabase CLI and verify bot health
- expose safe telegram-ping endpoint for manual bot pings
- add GitHub Actions workflow to run health checks

## Testing
- `bash scripts/env/install_supabase_cli.sh`
- `bash scripts/bot/health_check.sh`
- `npm test` *(fails: sh: 1: deno: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898234db8f08322ac91c544aa54d0ef