### PR TITLE
chore(bot): Telegram webhook secret fix kit (add-only)

### DIFF
--- a/docs/RUNBOOK_missing-telegram-secret.md
+++ b/docs/RUNBOOK_missing-telegram-secret.md
@@ -1,0 +1,25 @@
+# RUNBOOK — Missing TELEGRAM_WEBHOOK_SECRET
+
+## 1) Set secret in Supabase Edge
+
+npx supabase login
+npx supabase link --project-ref <PROJECT_REF>
+
+generate one if needed: openssl rand -hex 32
+
+npx supabase secrets set TELEGRAM_WEBHOOK_SECRET=<SAME_VALUE_YOU_WILL_SET_ON_TELEGRAM>
+npx supabase functions deploy telegram-bot
+
+## 2) Register webhook with the SAME secret
+
+export TELEGRAM_BOT_TOKEN=xxxxx
+export TELEGRAM_WEBHOOK_SECRET=<SAME_VALUE_AS_ABOVE>
+export TELEGRAM_WEBHOOK_URL="https://<PROJECT_REF>.functions.supabase.co/telegram-bot"
+deno run -A scripts/set-webhook.ts
+
+## 3) Verify + ping
+
+deno run -A scripts/check-webhook.ts
+deno run -A scripts/ping-webhook.ts
+
+If `/start` still doesn’t reply: check Edge logs for `sendMessage` status or secret mismatch; confirm chat_id & token.


### PR DESCRIPTION
/automerge method=squash require=checks,approvals>=1
Adds add-only scripts + runbook to resolve “Missing TELEGRAM_WEBHOOK_SECRET”:
- scripts/check-webhook.ts
- scripts/set-webhook.ts
- scripts/ping-webhook.ts
- docs/RUNBOOK_missing-telegram-secret.md
No existing files modified. Secrets are set via Supabase Edge; webhook is registered with the same secret.

After merge (you run locally)

npx supabase login
npx supabase link --project-ref <PROJECT_REF>
npx supabase secrets set TELEGRAM_WEBHOOK_SECRET=$(openssl rand -hex 32)
npx supabase functions deploy telegram-bot

export TELEGRAM_BOT_TOKEN=xxxxx
export TELEGRAM_WEBHOOK_SECRET=<same value>
export TELEGRAM_WEBHOOK_URL="https://<PROJECT_REF>.functions.supabase.co/telegram-bot"

deno run -A scripts/set-webhook.ts
deno run -A scripts/check-webhook.ts
deno run -A scripts/ping-webhook.ts

------
https://chatgpt.com/codex/tasks/task_e_68994d66c8f48322b76c42a844ce7c13