### PR TITLE
chore(miniapp): ensure shared Supabase Edge host usage

### DIFF
--- a/apps/mini/src/hooks/useTelegram.ts
+++ b/apps/mini/src/hooks/useTelegram.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { functionUrl } from "../lib/edge";
 
 interface TelegramWebApp {
   themeParams?: Record<string, string>;
@@ -38,33 +39,52 @@ export function useTelegram() {
         Telegram?: { WebApp?: { initData?: string } };
       }).Telegram?.WebApp?.initData;
       if (initData) {
-        fetch(
-          "https://qeejuomcapbdlhnjqjcc.functions.supabase.co/verify-telegram",
-          {
+        const verifyUrl = functionUrl("verify-telegram");
+        if (verifyUrl) {
+          fetch(verifyUrl, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ initData }),
-          },
-        )
-          .then(async (res) => {
-            const json = await res.json().catch(() => null);
-            return { ok: res.ok, json };
           })
-          .then(({ ok, json }) => {
-            if (ok && json?.ok) {
-              (root as HTMLElement).dataset.tgVerified = "true";
-              console.log("[MiniApp] Telegram initData verified", json.user);
-            } else {
-              (root as HTMLElement).dataset.tgVerified = "false";
-              console.warn(
-                "[MiniApp] Telegram initData verification failed",
-                json,
-              );
-            }
+            .then(async (res) => {
+              const json = await res.json().catch(() => null);
+              return { ok: res.ok, json };
+            })
+            .then(({ ok, json }) => {
+              if (ok && json?.ok) {
+                (root as HTMLElement).dataset.tgVerified = "true";
+                console.log("[MiniApp] Telegram initData verified", json.user);
+              } else {
+                (root as HTMLElement).dataset.tgVerified = "false";
+                console.warn(
+                  "[MiniApp] Telegram initData verification failed",
+                  json,
+                );
+              }
+            })
+            .catch((err) =>
+              console.error("[MiniApp] verify-telegram error", err)
+            );
+        }
+
+        const healthUrl = functionUrl("miniapp-health");
+        if (healthUrl) {
+          fetch(healthUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ initData }),
           })
-          .catch((err) =>
-            console.error("[MiniApp] verify-telegram error", err)
-          );
+            .then((res) => res.json().catch(() => null))
+            .then((json) => {
+              const vip = json?.vip?.is_vip;
+              if (vip !== undefined) {
+                (root as HTMLElement).dataset.tgVip = String(!!vip);
+              }
+            })
+            .catch((err) =>
+              console.error("[MiniApp] miniapp-health error", err)
+            );
+        }
       }
     } catch (e) {
       console.warn("[MiniApp] Unable to verify Telegram initData", e);

--- a/apps/mini/src/lib/edge.ts
+++ b/apps/mini/src/lib/edge.ts
@@ -1,0 +1,14 @@
+export function functionUrl(name: string): string | null {
+  const ref =
+    (import.meta as any).env?.VITE_SUPABASE_PROJECT_ID ||
+    (() => {
+      try {
+        const url = (import.meta as any).env?.VITE_SUPABASE_URL;
+        return url ? new URL(url).hostname.split('.')[0] : null;
+      } catch {
+        return null;
+      }
+    })() ||
+    new URLSearchParams(globalThis.location?.search || '').get('pr');
+  return ref ? `https://${ref}.functions.supabase.co/${name}` : null;
+}

--- a/tests/miniapp-edge-host.test.ts
+++ b/tests/miniapp-edge-host.test.ts
@@ -1,0 +1,11 @@
+import { assert } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+
+Deno.test("useTelegram hook uses shared functionUrl helper", async () => {
+  const text = await Deno.readTextFile("apps/mini/src/hooks/useTelegram.ts");
+  assert(!text.includes("functions.supabase.co"), "hard-coded host found");
+  assert(text.includes("functionUrl("), "functionUrl helper missing");
+  assert(
+    text.includes('functionUrl("verify-telegram"'),
+    "verify-telegram endpoint missing",
+  );
+});


### PR DESCRIPTION
## Summary
- add front-end helper to derive Supabase Edge host from env or query
- verify Telegram init data and health via shared helper in mini app
- check mini app uses helper via new regression test

## Testing
- `npm test`
- `deno run --no-npm -A scripts/audit-edge-hosts.ts`
- `deno run --no-npm -A scripts/check-linkage.ts`


------
https://chatgpt.com/codex/tasks/task_e_689972826a888322bcd3021023a7e68a