### PR TITLE
Send mini app button on Telegram /start

### DIFF
--- a/tests/telegram-webhook.test.ts
+++ b/tests/telegram-webhook.test.ts
@@ -2,6 +2,7 @@ import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
 
 Deno.test("webhook handles /start with params", async () => {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
+  Deno.env.set("MINI_APP_URL", "https://example.com/app");
   const calls: Array<{ url: string; body: string }> = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
@@ -19,7 +20,47 @@ Deno.test("webhook handles /start with params", async () => {
     assertEquals(res.status, 200);
     assertEquals(calls.length, 1);
     assertEquals(calls[0].url, "https://api.telegram.org/bottesttoken/sendMessage");
+    const payload = JSON.parse(calls[0].body);
+    assertEquals(
+      payload.reply_markup.inline_keyboard[0][0].web_app.url,
+      "https://example.com/app/",
+    );
   } finally {
     globalThis.fetch = originalFetch;
+    Deno.env.delete("MINI_APP_URL");
+    Deno.env.delete("TELEGRAM_BOT_TOKEN");
+  }
+});
+
+Deno.test("webhook handles /start with short name", async () => {
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
+  Deno.env.set("MINI_APP_SHORT_NAME", "vipapp");
+  Deno.env.set("TELEGRAM_BOT_USERNAME", "vip_bot");
+  const calls: Array<{ url: string; body: string }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), body: init?.body ? String(init.body) : "" });
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+  try {
+    const mod = await import("../supabase/functions/telegram-webhook/index.ts");
+    const req = new Request("https://example.com", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: { text: "/start", chat: { id: 1 } } }),
+    });
+    const res = await mod.handler(req);
+    assertEquals(res.status, 200);
+    assertEquals(calls.length, 1);
+    const payload = JSON.parse(calls[0].body);
+    assertEquals(
+      payload.reply_markup.inline_keyboard[0][0].web_app.url,
+      "https://t.me/vip_bot/vipapp",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    Deno.env.delete("MINI_APP_SHORT_NAME");
+    Deno.env.delete("TELEGRAM_BOT_USERNAME");
+    Deno.env.delete("TELEGRAM_BOT_TOKEN");
   }
 });


### PR DESCRIPTION
## Summary
- expose optional `reply_markup` in `sendMessage` helper
- reply to `/start` with mini app button when `MINI_APP_URL` or `MINI_APP_SHORT_NAME` set
- add test coverage for launching mini app via short name link

## Testing
- `npm test` *(fails: Module not found "file:///workspace/Dynamic-Chatty-Bot/supabase/functions/telegram-bot/vendor/esm.sh/@supabase/supabase-js@2")*
- `deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A --no-check tests/telegram-webhook.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6899dc38810083228151cc37a1eac9eb