### PR TITLE
warn when bot token missing

### DIFF
--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -21,7 +21,10 @@ async function sendMessage(
   extra?: Record<string, unknown>,
 ) {
   const token = optionalEnv("TELEGRAM_BOT_TOKEN");
-  if (!token) return;
+  if (!token) {
+    console.warn("TELEGRAM_BOT_TOKEN not set; cannot send message");
+    return;
+  }
   try {
     await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
       method: "POST",


### PR DESCRIPTION
## Summary
- log warning when TELEGRAM_BOT_TOKEN is not set to avoid silent failures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689abe53bcb08322afe0dfbccc025e2f