### PR TITLE
Enforce webhook secret validation and secure sync audit

### DIFF
--- a/supabase/functions/_shared/telegram_secret.ts
+++ b/supabase/functions/_shared/telegram_secret.ts
@@ -17,14 +17,17 @@ export async function readDbWebhookSecret(
   try {
     if (supa) {
       const { data } = await supa.from("bot_settings")
-        .select("setting_value").eq("setting_key", "TELEGRAM_WEBHOOK_SECRET")
-        .limit(1).maybeSingle();
+        .select("setting_value")
+        .eq("setting_key", "TELEGRAM_WEBHOOK_SECRET")
+        .eq("is_active", "true")
+        .limit(1)
+        .maybeSingle();
       return (data?.setting_value as string) || null;
     }
     const url = need("SUPABASE_URL");
     const key = need("SUPABASE_SERVICE_ROLE_KEY");
     const resp = await fetch(
-      `${url}/rest/v1/bot_settings?select=setting_value&setting_key=eq.TELEGRAM_WEBHOOK_SECRET&limit=1`,
+      `${url}/rest/v1/bot_settings?select=setting_value&setting_key=eq.TELEGRAM_WEBHOOK_SECRET&is_active=eq.true&limit=1`,
       {
         headers: {
           apikey: key,
@@ -46,10 +49,16 @@ export async function expectedSecret(
 export async function validateTelegramHeader(
   req: Request,
 ): Promise<Response | null> {
-  const got = req.headers.get("X-Telegram-Bot-Api-Secret-Token") ||
-    req.headers.get("x-telegram-bot-api-secret-token") || "";
+  const url = new URL(req.url);
+  if (
+    req.method === "GET" &&
+    (url.pathname.endsWith("/version") || url.pathname.endsWith("/echo"))
+  ) {
+    return null;
+  }
   const exp = await expectedSecret();
-  if (!exp) return null;
-  if (got !== exp) return unauth("Secret mismatch");
+  if (!exp) return unauth("missing secret");
+  const got = req.headers.get("x-telegram-bot-api-secret-token");
+  if (!got || got !== exp) return unauth("bad secret");
   return null;
 }

--- a/tests/telegram-webhook.test.ts
+++ b/tests/telegram-webhook.test.ts
@@ -3,6 +3,7 @@ import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
 Deno.test("webhook handles /start with params", async () => {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
   Deno.env.set("MINI_APP_URL", "https://example.com/app");
+  Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
   const calls: Array<{ url: string; body: string }> = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
@@ -13,7 +14,10 @@ Deno.test("webhook handles /start with params", async () => {
     const mod = await import("../supabase/functions/telegram-webhook/index.ts");
     const req = new Request("https://example.com", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Telegram-Bot-Api-Secret-Token": "testsecret",
+      },
       body: JSON.stringify({ message: { text: "/start deep", chat: { id: 1 } } }),
     });
     const res = await mod.handler(req);
@@ -35,6 +39,7 @@ Deno.test("webhook uses short name when URL absent", async () => {
   Deno.env.delete("MINI_APP_URL");
   Deno.env.set("MINI_APP_SHORT_NAME", "shorty");
   Deno.env.set("TELEGRAM_BOT_USERNAME", "mybot");
+  Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
   const calls: Array<{ url: string; body: string }> = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
@@ -45,7 +50,10 @@ Deno.test("webhook uses short name when URL absent", async () => {
     const mod = await import("../supabase/functions/telegram-webhook/index.ts");
     const req = new Request("https://example.com", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Telegram-Bot-Api-Secret-Token": "testsecret",
+      },
       body: JSON.stringify({ message: { text: "/start", chat: { id: 1 } } }),
     });
     const res = await mod.handler(req);
@@ -64,6 +72,7 @@ Deno.test("webhook uses short name when URL absent", async () => {
 Deno.test("webhook falls back for invalid mini app url", async () => {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
   Deno.env.set("MINI_APP_URL", "http://invalid-url");
+  Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
   const calls: Array<{ url: string; body: string }> = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
@@ -74,7 +83,10 @@ Deno.test("webhook falls back for invalid mini app url", async () => {
     const mod = await import("../supabase/functions/telegram-webhook/index.ts");
     const req = new Request("https://example.com", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Telegram-Bot-Api-Secret-Token": "testsecret",
+      },
       body: JSON.stringify({ message: { text: "/start", chat: { id: 1 } } }),
     });
     const res = await mod.handler(req);


### PR DESCRIPTION
## Summary
- tighten Telegram webhook secret handling and expose a public version/echo check
- add admin secret requirement for sync-audit endpoint
- update tests to send webhook secret header

## Testing
- `npm test`
- `npx supabase login --token "$SUPABASE_ACCESS_TOKEN"` *(fails: Access token not provided)*
- `npx supabase secrets set TELEGRAM_WEBHOOK_SECRET="$SECRET_HEX" --project-ref qeejuomcapbdlhnjqjcc` *(fails: Access token not provided)*
- `npx supabase functions deploy miniapp --project-ref qeejuomcapbdlhnjqjcc` *(fails: Access token not provided)*
- `npx supabase functions deploy telegram-bot --project-ref qeejuomcapbdlhnjqjcc` *(fails: Access token not provided)*
- `curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/telegram-bot" ...`

------
https://chatgpt.com/codex/tasks/task_e_689bb4f4af70832299e1112e65d871df