### PR TITLE
Ensure miniapp edge function ships static assets

### DIFF
--- a/supabase/functions/miniapp/config.toml
+++ b/supabase/functions/miniapp/config.toml
@@ -1,0 +1,1 @@
+include = ["static/**"]


### PR DESCRIPTION
## Summary
- Include `static/` directory when deploying the `miniapp` edge function

## Testing
- `npx supabase secrets set TELEGRAM_BOT_TOKEN=placeholder TELEGRAM_WEBHOOK_SECRET=placeholder MINI_APP_URL=https://example.com/ --project-ref qeejuomcapbdlhnjqjcc`
- `npx supabase functions deploy miniapp --project-ref qeejuomcapbdlhnjqjcc`
- `npx supabase functions deploy telegram-bot --project-ref qeejuomcapbdlhnjqjcc`
- `curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" -d "url=${WEBHOOK_URL}"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c0c88e1b083228a5044a1b97c4ecb