### PR TITLE
chore: pin Deno std import version

### DIFF
--- a/supabase/functions/_shared/static.ts
+++ b/supabase/functions/_shared/static.ts
@@ -1,6 +1,6 @@
 // supabase/functions/_shared/static.ts
 import { mna, nf, ok } from "./http.ts";
-import { lookup } from "https://deno.land/std/media_types/mod.ts";
+import { lookup } from "https://deno.land/std@0.224.0/media_types/mod.ts";
 
 export type StaticOpts = {
   rootDir: URL; // e.g., new URL("../miniapp/static/", import.meta.url)


### PR DESCRIPTION
## Summary
- pin `media_types` import in shared static helper to `std@0.224.0`

## Testing
- `deno task fmt` *(fails: Found 98 not formatted files in 354 files)*
- `deno task lint` *(fails: Found 311 problems)*
- `deno task check` *(fails: invalid peer certificate while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689d72c169e08322b30cade1ae24aa5a