### PR TITLE
feat: add copyable price

### DIFF
--- a/apps/miniapp-react/src/shared/CopyableText.tsx
+++ b/apps/miniapp-react/src/shared/CopyableText.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+
+export default function CopyableText({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+    } catch {
+      const textarea = document.createElement("textarea");
+      textarea.value = value;
+      textarea.style.position = "fixed";
+      textarea.style.left = "-9999px";
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+    } finally {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
+  };
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span>{value}</span>
+      <button
+        type="button"
+        onClick={copy}
+        aria-label="Copy to clipboard"
+        className="p-1 rounded opacity-70 hover:opacity-100"
+      >
+        <svg
+          className="w-3.5 h-3.5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      </button>
+      {copied && <span className="text-xs">Copied!</span>}
+    </span>
+  );
+}

--- a/apps/miniapp-react/src/shared/PackageCard.tsx
+++ b/apps/miniapp-react/src/shared/PackageCard.tsx
@@ -1,12 +1,16 @@
+import CopyableText from "./CopyableText";
+
 type P = { id: string; name: string; price: number; currency: string; thumbnail_url?: string; description?: string };
 export default function PackageCard({ pkg }: { pkg: P }) {
   return (
     <div className="grid grid-cols-[80px,1fr,auto] gap-3 items-center rounded-2xl shadow p-3 bg-white/80 dark:bg-slate-800/80 backdrop-blur">
       <img src={pkg.thumbnail_url || 'https://via.placeholder.com/80'} className="w-20 h-20 rounded-xl object-cover" />
       <div className="min-w-0">
-        <div className="font-medium truncate">{pkg.name}</div>
-        <div className="text-sm opacity-70 line-clamp-2">{pkg.description || ''}</div>
-        <div className="mt-1 text-sm">{pkg.price} {pkg.currency}</div>
+          <div className="font-medium truncate">{pkg.name}</div>
+          <div className="text-sm opacity-70 line-clamp-2">{pkg.description || ''}</div>
+          <div className="mt-1 text-sm">
+            <CopyableText value={`${pkg.price} ${pkg.currency}`} />
+          </div>
       </div>
       <button className="btn bg-blue-600 text-white text-sm hover:bg-blue-700">Details</button>
     </div>


### PR DESCRIPTION
## Summary
- add CopyableText component to copy text with a button
- wrap package price in CopyableText and show copy icon

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dad6190508322b3536bd6a6974c68