### PR TITLE
feat: handle missing index.html in miniapp

### DIFF
--- a/supabase/functions/miniapp/fallback.test.ts
+++ b/supabase/functions/miniapp/fallback.test.ts
@@ -1,16 +1,17 @@
-import { assertEquals, assert } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 
-Deno.test("serves 500 page when index.html fails to load", async () => {
-  const original = Deno.readFile;
-  (Deno as unknown as { readFile: typeof Deno.readFile }).readFile = () => {
-    throw new Error("boom");
-  };
+Deno.test("returns 404 when index.html fails to load", async () => {
+  const original = Deno.readTextFile;
+  (Deno as unknown as { readTextFile: typeof Deno.readTextFile }).readTextFile =
+    () => {
+      throw new Error("boom");
+    };
 
   const { handler } = await import("./index.ts");
-  (Deno as unknown as { readFile: typeof Deno.readFile }).readFile = original;
+  (Deno as unknown as { readTextFile: typeof Deno.readTextFile }).readTextFile =
+    original;
 
   const res = await handler(new Request("http://example.com/"));
-  assertEquals(res.status, 500);
-  const text = await res.text();
-  assert(text.includes("Internal Server Error") || text.includes("500"));
+  assertEquals(res.status, 404);
+  assertEquals(await res.text(), "Index file not found");
 });

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -3,27 +3,18 @@ import { serveStatic } from "../_shared/static.ts";
 
 const rootDir = new URL("./static/", import.meta.url);
 
-async function loadIndexHtml() {
-  await Deno.readFile(new URL("./index.html", rootDir));
-}
-
-const errorPage = new Response("<h1>Internal Server Error</h1>", {
-  status: 500,
-  headers: { "content-type": "text/html" },
-});
-
 let handler: (req: Request) => Response | Promise<Response>;
 
 try {
-  await loadIndexHtml();
+  await Deno.readTextFile(new URL("./index.html", rootDir));
   handler = (req) =>
     serveStatic(req, {
       rootDir,
       spaRoots: ["/", "/miniapp"],
     });
 } catch {
-  console.error("[miniapp] failed to load index.html");
-  handler = () => errorPage;
+  console.warn("[miniapp] index.html not found");
+  handler = () => new Response("Index file not found", { status: 404 });
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
## Summary
- handle missing index.html in miniapp by returning 404
- warn when index.html is missing and avoid server error
- test 404 fallback when index.html cannot be read

## Testing
- `DENO_NO_PACKAGE_JSON=1 deno test --unsafely-ignore-certificate-errors=deno.land,registry.npmjs.org -A supabase/functions/miniapp/fallback.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689f2a0e27c883229b2e66d4913025e8