### PR TITLE
chore: remove any types from status page

### DIFF
--- a/supabase/functions/miniapp/src/components/StatusPill.tsx
+++ b/supabase/functions/miniapp/src/components/StatusPill.tsx
@@ -5,7 +5,7 @@ const variants = {
   REVIEW: "dc-pill--review",
 } as const;
 
-type Status = keyof typeof variants;
+export type Status = keyof typeof variants;
 
 interface Props {
   status: Status;

--- a/supabase/functions/miniapp/src/pages/Status.tsx
+++ b/supabase/functions/miniapp/src/pages/Status.tsx
@@ -2,13 +2,13 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import TopBar from "../components/TopBar";
 import GlassRow from "../components/GlassRow";
-import StatusPill from "../components/StatusPill";
+import StatusPill, { type Status } from "../components/StatusPill";
 import { useApi } from "../hooks/useApi";
 
 interface Receipt {
   id: string;
   amount: number;
-  status: string;
+  status: Status;
   created_at: string;
 }
 
@@ -19,9 +19,10 @@ export default function Status() {
   const [receipt, setReceipt] = useState<Receipt | null>(null);
 
   useEffect(() => {
-    api.getReceipts(5).then((res: any) => {
+    type ReceiptsResponse = Receipt[] | { items: Receipt[] };
+    api.getReceipts(5).then((res: ReceiptsResponse) => {
       const items = Array.isArray(res) ? res : res.items || [];
-      const found = items.find((r: Receipt) => r.id === paymentId) || items[0];
+      const found = items.find((r) => r.id === paymentId) || items[0];
       setReceipt(found || null);
     });
   }, [api, paymentId]);
@@ -29,15 +30,14 @@ export default function Status() {
   return (
     <div className="dc-screen">
       <TopBar title="Payment Status" />
-      {receipt ? (
-        <GlassRow
-          left={<span className="text-sm">{receipt.id.slice(0, 6)}…</span>}
-          right={<StatusPill status={receipt.status as any} />}
-        />
-      ) : (
-        <p className="p-4 text-sm">No payment information available.</p>
-      )}
+      {receipt
+        ? (
+          <GlassRow
+            left={<span className="text-sm">{receipt.id.slice(0, 6)}…</span>}
+            right={<StatusPill status={receipt.status} />}
+          />
+        )
+        : <p className="p-4 text-sm">No payment information available.</p>}
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- define and export `Status` type for status pill component
- type receipt status and API response without using `any`

## Testing
- `npm run lint`
- `deno task typecheck` *(fails: invalid peer certificate for npm registry)*
- `deno task fmt` *(fails: invalid peer certificate for npm registry)*
- `deno task lint` *(fails: invalid peer certificate for npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_689fa2f5b0e8832299d1c932639dd01f