### PR TITLE
Add smoke scripts and webhook security tests

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -26,5 +26,14 @@ else
   echo "No tests found, skipping."
 fi
 
+if [ -n "${FUNCTIONS_BASE:-}" ]; then
+  echo "== smoke-miniapp =="
+  $DENO_BIN run -A scripts/smoke-miniapp.ts
+  echo "== smoke-bot =="
+  $DENO_BIN run -A scripts/smoke-bot.ts
+else
+  echo "FUNCTIONS_BASE not set; skipping smoke scripts."
+fi
+
 echo "CI checks passed."
 # <<< DC BLOCK: ci-core (end)

--- a/scripts/smoke-bot.ts
+++ b/scripts/smoke-bot.ts
@@ -1,0 +1,29 @@
+const base = Deno.env.get("FUNCTIONS_BASE");
+if (!base) {
+  console.error("FUNCTIONS_BASE not set");
+  Deno.exit(1);
+}
+
+async function expect(path: string, init: RequestInit, status: number) {
+  const res = await fetch(`${base}${path}`, init);
+  if (res.status !== status) {
+    console.error(
+      `${init.method ?? "GET"} ${path} -> ${res.status} (expected ${status})`,
+    );
+    Deno.exit(1);
+  }
+  console.log(`${init.method ?? "GET"} ${path} -> ${res.status}`);
+}
+
+await expect("/telegram-bot", { method: "GET" }, 405);
+await expect(
+  "/telegram-bot",
+  {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{}",
+  },
+  401,
+);
+
+console.log("smoke-bot ok");

--- a/scripts/smoke-miniapp.ts
+++ b/scripts/smoke-miniapp.ts
@@ -1,0 +1,19 @@
+const base = Deno.env.get("FUNCTIONS_BASE");
+if (!base) {
+  console.error("FUNCTIONS_BASE not set");
+  Deno.exit(1);
+}
+
+async function expect(path: string, status: number) {
+  const res = await fetch(`${base}${path}`);
+  if (res.status !== status) {
+    console.error(`${path} -> ${res.status} (expected ${status})`);
+    Deno.exit(1);
+  }
+  console.log(`${path} -> ${res.status}`);
+}
+
+await expect("/miniapp/version", 200);
+await expect("/nonexistent", 404);
+
+console.log("smoke-miniapp ok");

--- a/tests/bot-webhook-security.test.ts
+++ b/tests/bot-webhook-security.test.ts
@@ -1,0 +1,68 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+
+async function loadHandler() {
+  const mod = await import("../supabase/functions/telegram-webhook/index.ts");
+  return mod.handler as (req: Request) => Promise<Response>;
+}
+
+function setSecret(secret: string) {
+  Deno.env.set("TELEGRAM_WEBHOOK_SECRET", secret);
+}
+
+function clearSecret() {
+  Deno.env.delete("TELEGRAM_WEBHOOK_SECRET");
+}
+
+Deno.test("bot webhook rejects missing secret", async () => {
+  setSecret("testsecret");
+  try {
+    const handler = await loadHandler();
+    const req = new Request("https://example.com/telegram-bot", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    const res = await handler(req);
+    assertEquals(res.status, 401);
+  } finally {
+    clearSecret();
+  }
+});
+
+Deno.test("bot webhook rejects wrong secret", async () => {
+  setSecret("correct");
+  try {
+    const handler = await loadHandler();
+    const req = new Request("https://example.com/telegram-bot", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-Telegram-Bot-Api-Secret-Token": "wrong",
+      },
+      body: "{}",
+    });
+    const res = await handler(req);
+    assertEquals(res.status, 401);
+  } finally {
+    clearSecret();
+  }
+});
+
+Deno.test("bot webhook accepts correct secret", async () => {
+  setSecret("right");
+  try {
+    const handler = await loadHandler();
+    const req = new Request("https://example.com/telegram-bot", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-Telegram-Bot-Api-Secret-Token": "right",
+      },
+      body: "{}",
+    });
+    const res = await handler(req);
+    assertEquals(res.status, 200);
+  } finally {
+    clearSecret();
+  }
+});


### PR DESCRIPTION
## Summary
- add smoke-miniapp.ts and smoke-bot.ts to verify basic endpoint responses
- cover Telegram webhook secret handling with new bot-webhook-security tests
- run smoke scripts in CI after test suite

## Testing
- `deno test -A --unsafely-ignore-certificate-errors=registry.npmjs.org,deno.land tests/bot-webhook-security.test.ts`
- `bash scripts/ci.sh` *(fails: Found 118 not formatted files in 368 files)*

------
https://chatgpt.com/codex/tasks/task_e_68a042fae17c8322ae784b4abb91ff91