### PR TITLE
test: cover mini app launch states

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -244,6 +244,7 @@ export async function sendMiniAppLink(chatId: number): Promise<string | null> {
   }
 
   const rawUrl = optionalEnv("MINI_APP_URL") || "";
+  const miniShort = optionalEnv("MINI_APP_SHORT_NAME") || "";
 
   // Normalize MINI_APP_URL if present
   let miniUrl: string | null = null;
@@ -275,9 +276,20 @@ export async function sendMiniAppLink(chatId: number): Promise<string | null> {
     }
     return miniUrl;
   }
+
+  if (miniShort && botUsername) {
+    const link = `https://t.me/${botUsername}/${miniShort}`;
+    await sendMessage(chatId, "Join the VIP Mini App:", {
+      reply_markup: {
+        inline_keyboard: [[{ text: "Join", url: link }]],
+      },
+    });
+    return link;
+  }
+
   await sendMessage(
     chatId,
-    "Mini app is not configured. Please set MINI_APP_URL.",
+    "Mini app is being configured. Please try again soon.",
   );
   return null;
 }

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -88,6 +88,7 @@ export async function handler(req: Request): Promise<Response> {
     const handlers: Record<string, CommandHandler> = {
       "/start": async (chatId) => {
         const rawUrl = optionalEnv("MINI_APP_URL") || "";
+        const miniShort = optionalEnv("MINI_APP_SHORT_NAME") || "";
         const botUsername = optionalEnv("TELEGRAM_BOT_USERNAME") || "";
 
         let miniUrl: string | null = null;
@@ -115,12 +116,13 @@ export async function handler(req: Request): Promise<Response> {
           return;
         }
 
-        if (botUsername) {
-          const deepLink = `https://t.me/${botUsername}?startapp=1`;
-          await sendMessage(
-            chatId,
-            `Join the VIP Mini App: ${deepLink}\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)`,
-          );
+        if (botUsername && miniShort) {
+          const link = `https://t.me/${botUsername}/${miniShort}`;
+          await sendMessage(chatId, "Join the VIP Mini App:", {
+            reply_markup: {
+              inline_keyboard: [[{ text: "Join", url: link }]],
+            },
+          });
           return;
         }
 

--- a/tests/telegram-webhook.test.ts
+++ b/tests/telegram-webhook.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { assertEquals, assert } from "https://deno.land/std@0.224.0/testing/asserts.ts";
 
 async function setConfig(key: string, val: unknown) {
   const mod = await import("../supabase/functions/_shared/config.ts");
@@ -9,14 +9,16 @@ Deno.test("webhook handles /start with params", async () => {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
   Deno.env.set(
     "MINI_APP_URL",
-    "https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/",
+    "https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp",
   );
   Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
   Deno.env.set("SUPABASE_URL", "http://local");
   Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
   Deno.env.set("SUPABASE_ANON_KEY", "anon");
   const calls: Array<{ url: string; body: string }> = [];
+  const logs: string[] = [];
   const originalFetch = globalThis.fetch;
+  const origLog = console.log;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
     const url = String(input);
     if (url.startsWith("https://api.telegram.org")) {
@@ -25,6 +27,7 @@ Deno.test("webhook handles /start with params", async () => {
     }
     return new Response("{}", { status: 200 });
   };
+  console.log = (...args: unknown[]) => logs.push(args.join(" "));
   try {
     await setConfig("features:published", { ts: Date.now(), data: { mini_app_enabled: true } });
     const mod = await import("../supabase/functions/telegram-webhook/index.ts");
@@ -45,8 +48,10 @@ Deno.test("webhook handles /start with params", async () => {
       payload.reply_markup.inline_keyboard[0][0].web_app.url,
       "https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/",
     );
+    assert(logs.every((l) => !l.includes(" 400")), "no 400 logs");
   } finally {
     globalThis.fetch = originalFetch;
+    console.log = origLog;
     await setConfig("features:published", { ts: Date.now(), data: { mini_app_enabled: false } });
     Deno.env.delete("SUPABASE_URL");
     Deno.env.delete("SUPABASE_SERVICE_ROLE_KEY");
@@ -54,7 +59,7 @@ Deno.test("webhook handles /start with params", async () => {
   }
 });
 
-Deno.test("webhook uses startapp link when URL absent", async () => {
+Deno.test("webhook warns when launch info missing", async () => {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
   Deno.env.delete("MINI_APP_URL");
   Deno.env.delete("MINI_APP_SHORT_NAME");
@@ -64,7 +69,9 @@ Deno.test("webhook uses startapp link when URL absent", async () => {
   Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
   Deno.env.set("SUPABASE_ANON_KEY", "anon");
   const calls: Array<{ url: string; body: string }> = [];
+  const logs: string[] = [];
   const originalFetch = globalThis.fetch;
+  const origLog = console.log;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
     const url = String(input);
     if (url.startsWith("https://api.telegram.org")) {
@@ -73,6 +80,7 @@ Deno.test("webhook uses startapp link when URL absent", async () => {
     }
     return new Response("{}", { status: 200 });
   };
+  console.log = (...args: unknown[]) => logs.push(args.join(" "));
   try {
     await setConfig("features:published", { ts: Date.now(), data: { mini_app_enabled: true } });
     const mod = await import("../supabase/functions/telegram-webhook/index.ts");
@@ -90,15 +98,69 @@ Deno.test("webhook uses startapp link when URL absent", async () => {
     const payload = JSON.parse(calls[0].body);
     assertEquals(
       payload.text,
-      "Join the VIP Mini App: https://t.me/mybot?startapp=1\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)",
+      "Bot activated. Mini app is being configured. Please try again soon.",
     );
     assertEquals(payload.reply_markup, undefined);
+    assert(logs.every((l) => !l.includes(" 400")), "no 400 logs");
   } finally {
     globalThis.fetch = originalFetch;
+    console.log = origLog;
     await setConfig("features:published", { ts: Date.now(), data: { mini_app_enabled: false } });
     Deno.env.delete("SUPABASE_URL");
     Deno.env.delete("SUPABASE_SERVICE_ROLE_KEY");
     Deno.env.delete("SUPABASE_ANON_KEY");
+  }
+});
+
+Deno.test("webhook uses short name when URL absent", async () => {
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
+  Deno.env.delete("MINI_APP_URL");
+  Deno.env.set("MINI_APP_SHORT_NAME", "shorty");
+  Deno.env.set("TELEGRAM_BOT_USERNAME", "mybot");
+  Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
+  Deno.env.set("SUPABASE_URL", "http://local");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
+  Deno.env.set("SUPABASE_ANON_KEY", "anon");
+  const calls: Array<{ url: string; body: string }> = [];
+  const logs: string[] = [];
+  const originalFetch = globalThis.fetch;
+  const origLog = console.log;
+  globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.startsWith("https://api.telegram.org")) {
+      calls.push({ url, body: init?.body ? String(init.body) : "" });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    return new Response("{}", { status: 200 });
+  };
+  console.log = (...args: unknown[]) => logs.push(args.join(" "));
+  try {
+    await setConfig("features:published", { ts: Date.now(), data: { mini_app_enabled: true } });
+    const mod = await import("../supabase/functions/telegram-webhook/index.ts");
+    const req = new Request("https://example.com", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Telegram-Bot-Api-Secret-Token": "testsecret",
+      },
+      body: JSON.stringify({ message: { text: "/start", chat: { id: 1 } } }),
+    });
+    const res = await mod.handler(req);
+    assertEquals(res.status, 200);
+    const payload = JSON.parse(calls[0].body);
+    const btn = payload.reply_markup.inline_keyboard[0][0];
+    assertEquals(btn.url, "https://t.me/mybot/shorty");
+    assertEquals(btn.web_app, undefined);
+    assert(logs.every((l) => !l.includes(" 400")), "no 400 logs");
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.log = origLog;
+    await setConfig("features:published", { ts: Date.now(), data: { mini_app_enabled: false } });
+    Deno.env.delete("SUPABASE_URL");
+    Deno.env.delete("SUPABASE_SERVICE_ROLE_KEY");
+    Deno.env.delete("SUPABASE_ANON_KEY");
+    Deno.env.delete("MINI_APP_SHORT_NAME");
+    Deno.env.delete("TELEGRAM_BOT_USERNAME");
   }
 });
 


### PR DESCRIPTION
## Summary
- handle MINI_APP_SHORT_NAME fallback and update config message
- test mini app link behavior for URL, short name, and missing config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a05ead3a1c832290cad30dc59f63b0