### PR TITLE
feat: export edge function handlers

### DIFF
--- a/supabase/functions/crypto-webhook/index.ts
+++ b/supabase/functions/crypto-webhook/index.ts
@@ -21,7 +21,7 @@ async function activateSubscription(
     );
 }
 
-serve(async (req) => {
+async function handler(req: Request): Promise<Response> {
   const url = new URL(req.url);
   if (req.method === "GET" && url.pathname.endsWith("/version")) {
     return ok({ name: "crypto-webhook", ts: new Date().toISOString() });
@@ -108,4 +108,10 @@ serve(async (req) => {
   }
 
   return ok({ status: isConfirmed ? "completed" : "pending" });
-});
+}
+
+if (import.meta.main) {
+  serve(handler);
+}
+
+export default handler;

--- a/supabase/functions/plans/index.ts
+++ b/supabase/functions/plans/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "../_shared/client.ts";
 
-serve(async (req) => {
+async function handler(req: Request): Promise<Response> {
   if (req.method !== "GET") {
     return new Response("Method Not Allowed", { status: 405 });
   }
@@ -10,7 +10,9 @@ serve(async (req) => {
 
   const { data, error } = await supa
     .from("subscription_plans")
-    .select("id,name,duration_months,price,currency,is_lifetime,features,created_at")
+    .select(
+      "id,name,duration_months,price,currency,is_lifetime,features,created_at",
+    )
     .order("price", { ascending: true });
 
   if (error) {
@@ -24,4 +26,10 @@ serve(async (req) => {
     JSON.stringify({ ok: true, plans: data }),
     { headers: { "content-type": "application/json" } },
   );
-});
+}
+
+if (import.meta.main) {
+  serve(handler);
+}
+
+export default handler;

--- a/supabase/functions/verify-telegram/index.ts
+++ b/supabase/functions/verify-telegram/index.ts
@@ -99,12 +99,14 @@ async function verifyInitData(initData: string) {
   return { ok: true, user } as const;
 }
 
-Deno.serve(async (req) => {
+async function handler(req: Request): Promise<Response> {
   const url = new URL(req.url);
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
-  if (req.method === "HEAD") return withCors(new Response(null, { status: 200 }));
+  if (req.method === "HEAD") {
+    return withCors(new Response(null, { status: 200 }));
+  }
   if (req.method === "GET" && url.pathname.endsWith("/version")) {
     return withCors(ok({ name: "verify-telegram", ts: new Date().toISOString() }));
   }
@@ -123,4 +125,10 @@ Deno.serve(async (req) => {
     console.error("verify-telegram error", err);
     return withCors(oops("SERVER_ERROR", String(err)));
   }
-});
+}
+
+if (import.meta.main) {
+  Deno.serve(handler);
+}
+
+export default handler;


### PR DESCRIPTION
## Summary
- add explicit handler export for plans edge function
- expose handler function in verify-telegram function with default export
- export handler in crypto-webhook for clarity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0ac1fd1988322afdd40f102abfcb7