### PR TITLE
Reduce queue worker delay when awaiting future jobs

### DIFF
--- a/src/queue/index.ts
+++ b/src/queue/index.ts
@@ -138,7 +138,8 @@ export async function workerLoop() {
     }
     const now = Date.now();
     if (job.nextRunAt > now) {
-      await sleep(job.nextRunAt - now);
+      // Wake up periodically so new earlier jobs don't wait for a long sleep
+      await sleep(Math.min(job.nextRunAt - now, 50));
       continue;
     }
     queue.shift();


### PR DESCRIPTION
## Summary
- cap worker sleep duration so new queued jobs are processed promptly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1c8c4443c8322bd896f92a6160e55