### PR TITLE
Use Deno.stat for HEAD static file requests

### DIFF
--- a/miniapp/src/main.ts
+++ b/miniapp/src/main.ts
@@ -1,8 +1,18 @@
 import './style.css';
 
+interface TelegramWebApp {
+  ready: () => void;
+  close: () => void;
+  initData?: string;
+}
+
+interface TelegramNamespace {
+  WebApp?: TelegramWebApp;
+}
+
 declare global {
   interface Window {
-    Telegram: any;
+    Telegram?: TelegramNamespace;
   }
 }
 


### PR DESCRIPTION
## Summary
- Avoid reading file contents on HEAD requests by using `Deno.stat` and generating headers manually
- Improve HEAD request handling for assets and extra files
- Define Telegram Web App types to remove `any` usage in mini app

## Testing
- `npm run lint`
- `npm test` *(fails: deno: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b4daba888322b31f1d75632acf07