### PR TITLE
Handle /functions/v1 miniapp routing

### DIFF
--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -6,7 +6,12 @@ const securityHeaders = {
 
 export async function handler(req: Request): Promise<Response> {
   const url = new URL(req.url);
-  console.log(`[miniapp] Request: ${req.method} ${url.pathname} - Full URL: ${req.url}`);
+  if (url.pathname.startsWith("/functions/v1")) {
+    url.pathname = url.pathname.replace("/functions/v1", "");
+  }
+  console.log(
+    `[miniapp] Request: ${req.method} ${url.pathname} - Full URL: ${req.url}`,
+  );
 
   // Version endpoint
   if (url.pathname === "/miniapp/version") {
@@ -14,7 +19,9 @@ export async function handler(req: Request): Promise<Response> {
       ...securityHeaders,
       "content-type": "application/json; charset=utf-8",
     });
-    if (req.method === "HEAD") return new Response(null, { status: 200, headers });
+    if (req.method === "HEAD") {
+      return new Response(null, { status: 200, headers });
+    }
     return new Response(
       JSON.stringify({ name: "miniapp", ts: new Date().toISOString() }),
       { status: 200, headers },
@@ -26,7 +33,7 @@ export async function handler(req: Request): Promise<Response> {
     if (req.method !== "GET" && req.method !== "HEAD") {
       return new Response(null, { status: 405, headers: securityHeaders });
     }
-    
+
     const htmlContent = `<!doctype html>
 <html lang="en">
 <head>
@@ -413,11 +420,11 @@ export async function handler(req: Request): Promise<Response> {
       ...securityHeaders,
       "content-type": "text/html; charset=utf-8",
     });
-    
+
     if (req.method === "HEAD") {
       return new Response(null, { status: 200, headers });
     }
-    
+
     return new Response(htmlContent, { status: 200, headers });
   }
 
@@ -435,7 +442,9 @@ export async function handler(req: Request): Promise<Response> {
         ? "text/javascript; charset=utf-8"
         : "application/octet-stream";
       headers.set("content-type", type);
-      if (req.method === "HEAD") return new Response(null, { status: 200, headers });
+      if (req.method === "HEAD") {
+        return new Response(null, { status: 200, headers });
+      }
       return new Response(body, { status: 200, headers });
     } catch {
       return new Response(null, { status: 404, headers: securityHeaders });

--- a/tests/miniapp-edge-host-routing.test.ts
+++ b/tests/miniapp-edge-host-routing.test.ts
@@ -1,4 +1,7 @@
-import { assert, assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/testing/asserts.ts";
 import handler from "../supabase/functions/miniapp/index.ts";
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 
@@ -24,6 +27,28 @@ Deno.test({
       !bodyRoot.includes("Static <code>index.html</code> not found"),
       "should not serve fallback HTML",
     );
+
+    const resPrefixed = await fetch(`${base}/functions/v1/miniapp`);
+    assertEquals(resPrefixed.status, 200);
+    assertEquals(
+      resPrefixed.headers.get("content-type"),
+      "text/html; charset=utf-8",
+    );
+    const bodyPrefixed = await resPrefixed.text();
+    assert(
+      !bodyPrefixed.includes("Static <code>index.html</code> not found"),
+      "should not serve fallback HTML",
+    );
+
+    const resPrefixedHead = await fetch(`${base}/functions/v1/miniapp`, {
+      method: "HEAD",
+    });
+    assertEquals(resPrefixedHead.status, 200);
+    assertEquals(
+      resPrefixedHead.headers.get("content-type"),
+      "text/html; charset=utf-8",
+    );
+    await resPrefixedHead.arrayBuffer();
 
     const resVersion = await fetch(`${base}/miniapp/version`);
     assertEquals(resVersion.status, 200);
@@ -72,6 +97,12 @@ Deno.test({
     const resPost = await fetch(`${base}/miniapp/`, { method: "POST" });
     assertEquals(resPost.status, 405);
     await resPost.arrayBuffer();
+
+    const resPrefixedPost = await fetch(`${base}/functions/v1/miniapp`, {
+      method: "POST",
+    });
+    assertEquals(resPrefixedPost.status, 405);
+    await resPrefixedPost.arrayBuffer();
 
     controller.abort();
     try {


### PR DESCRIPTION
## Summary
- normalize miniapp handler to strip `/functions/v1` so prefixed requests route correctly
- test GET and HEAD requests for `/functions/v1/miniapp` and ensure non-GET still returns 405

## Testing
- `deno test -A --no-npm --unsafely-ignore-certificate-errors=deno.land,registry.npmjs.org`


------
https://chatgpt.com/codex/tasks/task_e_68a3f21c33c08322b27482ed8c7f77c5