### PR TITLE
feat: preserve content encoding when serving miniapp

### DIFF
--- a/supabase/functions/telegram-bot/vendor/esm.sh/@supabase/supabase-js@2.js
+++ b/supabase/functions/telegram-bot/vendor/esm.sh/@supabase/supabase-js@2.js
@@ -119,6 +119,14 @@ export function createClient(..._args) {
               return { data: null, error: { message: "not found" } };
             }
           },
+          info: async (key) => {
+            try {
+              await Deno.stat(`supabase/functions/miniapp/static/${key}`);
+              return { data: { httpMetadata: {} }, error: null };
+            } catch {
+              return { data: null, error: { message: "not found" } };
+            }
+          },
         };
       },
     },


### PR DESCRIPTION
## Summary
- add readFromStorage helper that respects existing content-encoding and recompresses text
- expose storage `info` in mock Supabase client for tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa7484be4c8322ac0157fd6e49610f