### PR TITLE
docs: add miniapp build instructions

### DIFF
--- a/supabase/functions/miniapp/README.md
+++ b/supabase/functions/miniapp/README.md
@@ -19,6 +19,19 @@ The app lives under `supabase/functions/miniapp`. It relies on existing Edge Fun
 SVG placeholders live in `supabase/functions/miniapp/static/img` for the logo, bank tiles and
 QR frame; replace them with production assets as needed.
 
+## Build
+
+Before deploying the miniapp Edge Function, generate the static assets:
+
+```bash
+npm run build
+# or
+./build.sh
+```
+
+This build step creates the `static/` directory that `index.ts` expects when
+serving `index.html` and related assets.
+
 ## Icons
 
 Buttons such as `PrimaryButton`, `SecondaryButton`, `ApproveButton`, and `RejectButton` accept an optional `icon` prop. For a consistent look, import icons from the [Heroicons React](https://github.com/tailwindlabs/heroicons) package:


### PR DESCRIPTION
## Summary
- document running the miniapp build before deployment
- note that index.ts serves from the generated `static/` directory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae49daa4a08322bc2bd1782d9da4b1