### PR TITLE
Handle network errors during promo code validation

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -1052,8 +1052,22 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
           headers,
           body: JSON.stringify({ code, telegram_id: userId, plan_id: planId }),
         },
-      ).then((r) => r.json()).catch(() => null);
-      if (!resp?.ok) {
+      ).then((r) => r.json()).catch((err) => {
+        console.error("promo-validate error", err);
+        return null;
+      });
+      if (!resp || typeof resp.ok !== "boolean") {
+        if (resp) console.error("promo-validate bad response", resp);
+        const msg =
+          "Could not validate promo code, please try again later";
+        if (cb.message) {
+          await editMessage(chatId, cb.message!.message_id!, msg);
+        } else {
+          await notifyUser(chatId, msg);
+        }
+        return;
+      }
+      if (!resp.ok) {
         const msg = "Invalid or expired promo code.";
         if (cb.message) {
           await editMessage(chatId, cb.message!.message_id!, msg);


### PR DESCRIPTION
## Summary
- Handle network failures when validating promo codes and send a retry message
- Log promo validation errors for monitoring

## Testing
- `npm test` *(fails: callback edits message instead of sending new one; Uncaught error from tests/main-menu.test.ts)*
- `npm run lint` *(fails: Unexpected any in supabase/functions/_tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e974519083229161055a5f6a823a